### PR TITLE
Add a widget area on home page

### DIFF
--- a/wp-content/themes/fhb/css/style.css
+++ b/wp-content/themes/fhb/css/style.css
@@ -728,3 +728,40 @@ div.tab.active {
 div.tab ul {
     margin-left: -1em;
 }
+
+/* Home page top sidebar */
+#home-top-sidebar p:last-of-type {
+    margin-bottom: 0;
+}
+
+#home-top-sidebar .wp-block-media-text {
+    grid-template-columns: 25% auto;
+}
+
+#home-top-sidebar .wp-block-media-text .wp-block-media-text__content {
+    padding: 0 0 0 5%;
+}
+
+@media (max-width: 550px) {
+    #home-top-sidebar .wp-block-media-text {
+        grid-template-columns: 0% auto !important;
+    }
+    #home-top-sidebar .wp-block-media-text .wp-block-media-text__content {
+        padding: 0;
+    }
+}
+
+@media (min-width: 640px) and (max-width: 959px) {
+    #home-top-sidebar .wp-block-media-text {
+        grid-template-columns: 0% auto !important;
+    }
+    #home-top-sidebar .wp-block-media-text .wp-block-media-text__content {
+        padding: 0;
+    }
+}
+
+@media (min-width: 960px) {
+    #home-top-sidebar .wp-block-media-text {
+        grid-template-columns: 18% auto;
+    }
+}

--- a/wp-content/themes/fhb/functions.php
+++ b/wp-content/themes/fhb/functions.php
@@ -132,15 +132,19 @@ function fhb_add_login_stylesheet() {
   wp_enqueue_style('custom-login', get_stylesheet_directory_uri() . '/css/style.css');
 }
 
-
-
-
-
-
-
-
-
-
-
+function fhb_register_sidebars() {
+  register_sidebar(
+    array(
+      'name'          => 'Home Top Sidebar',
+      'id'            => 'home-top-sidebar',
+      'description'   => 'Add widgets here to appear at the top of the home page.',
+      'before_widget' => '<div id="%1$s" class="widget %2$s">',
+      'after_widget'  => '</div>',
+      'before_title'  => '',
+      'after_title'   => '',
+    )
+  );
+} 
+add_action( 'widgets_init', 'fhb_register_sidebars' );
 
 ?>

--- a/wp-content/themes/fhb/home.php
+++ b/wp-content/themes/fhb/home.php
@@ -4,9 +4,7 @@
 <div class="uk-grid-collapse" uk-grid>
 
   <div class="uk-width-2-3@m uk-width-1-2@s">
-    <div class="uk-margin-left uk-margin-right uk-margin-top uk-text-small" uk-alert>
-      Spenden Sie jetzt an die Flüchtlingshilfe Babelsberg e.V. für Geflüchtete aus der Ukraine IBAN: DE68 1605 0000 1000 7267 00 bei der Mittelbrandenburgische Sparkasse, BIC WELADED1PMB, Stichwort: Potsdam hilft. <a href="https://fluechtlingshilfe-babelsberg.de/spenden/">Mehr Infos »</a>
-    </div>
+    <?php get_template_part('templates/home-top-sidebar'); ?>
     <div class="uk-grid-collapse uk-child-width-1-2@m uk-child-width-1-1@s" uk-grid>
       <?php $offers = new WP_Query(['post_type' => 'offers', 'posts_per_page' => -1]); ?>
       <?php if ($offers->post_count) {?>

--- a/wp-content/themes/fhb/templates/home-top-sidebar.php
+++ b/wp-content/themes/fhb/templates/home-top-sidebar.php
@@ -1,0 +1,5 @@
+<?php if ( is_active_sidebar( 'home-top-sidebar' ) ) : ?>
+  <div id="home-top-sidebar" class="uk-margin-left uk-margin-right uk-margin-top uk-text-small">
+    <?php dynamic_sidebar( 'home-top-sidebar' ); ?>
+   </div>
+<?php endif; ?>

--- a/wp-content/themes/fhb/templates/nav-top.php
+++ b/wp-content/themes/fhb/templates/nav-top.php
@@ -30,7 +30,6 @@
 			</ul>
 		</div>
 	</nav>
-
 	<?php if (get_the_post_thumbnail_url()): ?>
 		<div class="fhb-article-image" style="background-image: url(<?php echo get_the_post_thumbnail_url($post->ID, 'large'); ?>)">
 			<?php if (get_post_type() == 'page'): ?>


### PR DESCRIPTION
Add a widget area on home page to diplay things like the call for donations and change that content in the admin pages. The content can then be build using the normal blocks. This may then look e.g. like this:
![grafik](https://user-images.githubusercontent.com/101837871/160934849-d1124c0c-3906-413d-a816-ba5f031dfe1f.png)
